### PR TITLE
Recipients event

### DIFF
--- a/contracts/YlideMailerV7.tsol
+++ b/contracts/YlideMailerV7.tsol
@@ -1,0 +1,162 @@
+pragma ever-solidity >= 0.61.2;
+pragma AbiHeader expire;
+pragma AbiHeader pubkey;
+
+import './helpers/Owned.tsol';
+import './helpers/Terminatable.tsol';
+
+contract YlideMailerV7 is Owned, Terminatable {
+
+    uint256 public static nonce;
+
+    uint128 public contentPartFee = 0;
+    uint128 public recipientFee = 0;
+    uint128 public broadcastFee = 0;
+    address public static beneficiary;
+
+    event MailPush(address sender, uint256 msgId, bytes key);
+    event MailContent(address sender, uint256 msgId, uint16 parts, uint16 partIdx, bytes content);
+    event ContentRecipients(address sender, uint256 msgId, address[] recipients);
+    event MailBroadcast(uint256 msgId);
+
+    constructor() public {
+        require(tvm.pubkey() != 0, 101);
+        require(msg.pubkey() == tvm.pubkey(), 102);
+        tvm.accept();
+    }
+
+    function setFees(uint128 _contentPartFee, uint128 _recipientFee, uint128 _broadcastFee) public onlyOwner {
+        contentPartFee = _contentPartFee;
+        recipientFee = _recipientFee;
+        broadcastFee = _broadcastFee;
+    }
+
+    function setBeneficiary(address _beneficiary) public onlyOwner {
+        beneficiary = _beneficiary;
+    }
+
+    function buildHash(uint256 pubkey, uint32 uniqueId, uint32 time) public pure returns (uint256 _hash) {
+        bytes data = bytes(bytes32(pubkey));
+        data.append(bytes(bytes4(uniqueId)));
+        data.append(bytes(bytes4(time)));
+        _hash = sha256(data);
+    }
+
+    // Virtual function for initializing bulk message sending
+    function getMsgId(uint256 publicKey, uint32 uniqueId, uint32 initTime) public pure returns (uint256 msgId) {
+        msgId = buildHash(publicKey, uniqueId, initTime);
+    }
+
+    // Send part of the long message
+    function sendMultipartMailPart(uint32 uniqueId, uint32 initTime, uint16 parts, uint16 partIdx, bytes content) public view {
+        tvm.rawReserve(10 ton, 0);
+        require(msg.createdAt >= initTime, 103);
+        require(msg.createdAt - initTime <= 600, 104);
+
+        uint256 msgId = buildHash(msg.pubkey(), uniqueId, initTime);
+
+        // For indexation purposes
+        address fakeContentAddr = address.makeAddrExtern(msgId, 256);
+
+        emit MailContent{dest: fakeContentAddr}(msg.sender, msgId, parts, partIdx, content);
+
+        if (contentPartFee > 0) {
+            beneficiary.transfer({ value: contentPartFee, bounce: false });
+        }
+
+        msg.sender.transfer({ value: 0, flag: 128, bounce: false });
+    }
+
+    // Add recipient keys to some message
+    function addRecipients(uint32 uniqueId, uint32 initTime, address[] recipients, bytes[] keys) public view {
+        tvm.rawReserve(10 ton, 0);
+        uint256 msgId = buildHash(msg.pubkey(), uniqueId, initTime);
+        
+        for (uint i = 0; i < recipients.length; i++) {
+            address recipientAddr = address.makeAddrExtern(recipients[i].value, 256);
+            emit MailPush{dest: recipientAddr}(msg.sender, msgId, keys[i]);
+        }
+        emit ContentRecipients{dest: address.makeAddrExtern(msgId, 256)}(msg.sender, msgId, recipients);
+
+        if (recipientFee * recipients.length > 0) {
+            beneficiary.transfer({ value: uint128(recipientFee * recipients.length), bounce: false });
+        }
+
+        msg.sender.transfer({ value: 0, flag: 128, bounce: false });
+    }
+
+    function sendSmallMail(uint32 uniqueId, address recipient, bytes key, bytes content) public view {
+        tvm.rawReserve(10 ton, 0);
+        uint256 msgId = buildHash(msg.pubkey(), uniqueId, msg.createdAt);
+
+        // For indexation purposes
+        address fakeContentAddr = address.makeAddrExtern(msgId, 256);
+        address recipientAddr = address.makeAddrExtern(recipient.value, 256);
+
+        address[] recipients = new address[](1);
+        recipients[0] = recipient;
+
+        emit MailContent{dest: fakeContentAddr}(msg.sender, msgId, 1, 0, content);
+        emit MailPush{dest: recipientAddr}(msg.sender, msgId, key);
+        emit ContentRecipients{dest: fakeContentAddr}(msg.sender, msgId, recipients);
+
+        if (contentPartFee + recipientFee > 0) {
+            beneficiary.transfer({ value: uint128(contentPartFee + recipientFee), bounce: false });
+        }
+
+        msg.sender.transfer({ value: 0, flag: 128, bounce: false });
+    }
+
+    function sendBulkMail(uint32 uniqueId, address[] recipients, bytes[] keys, bytes content) public view {
+        tvm.rawReserve(10 ton, 0);
+        uint256 msgId = buildHash(msg.pubkey(), uniqueId, msg.createdAt);
+
+        // For indexation purposes
+        address fakeContentAddr = address.makeAddrExtern(msgId, 256);
+
+        emit MailContent{dest: fakeContentAddr}(msg.sender, msgId, 1, 0, content);
+
+        for (uint i = 0; i < recipients.length; i++) {
+            address recipientAddr = address.makeAddrExtern(recipients[i].value, 256);
+            emit MailPush{dest: recipientAddr}(msg.sender, msgId, keys[i]);
+        }
+
+        emit ContentRecipients{dest: fakeContentAddr}(msg.sender, msgId, recipients);
+
+        if (contentPartFee + recipientFee * recipients.length > 0) {
+            beneficiary.transfer({ value: uint128(contentPartFee + recipientFee * recipients.length), bounce: false });
+        }
+
+        msg.sender.transfer({ value: 0, flag: 128, bounce: false });
+    }
+
+    function broadcastMail(uint32 uniqueId, bytes content) public view {
+        tvm.rawReserve(10 ton, 0);
+        uint256 msgId = buildHash(msg.pubkey(), uniqueId, msg.createdAt);
+
+        // For indexation purposes
+        address fakeContentAddr = address.makeAddrExtern(msgId, 256);
+
+        emit MailContent{dest: fakeContentAddr}(msg.sender, msgId, 1, 0, content);
+        emit MailBroadcast{dest: address.makeAddrExtern(msg.sender.value, 256)}(msgId);
+
+        if (contentPartFee + broadcastFee > 0) {
+            beneficiary.transfer({ value: uint128(contentPartFee + broadcastFee), bounce: false });
+        }
+
+        msg.sender.transfer({ value: 0, flag: 128, bounce: false });
+    }
+
+    function broadcastMailHeader(uint32 uniqueId, uint32 initTime) public view {
+        tvm.rawReserve(10 ton, 0);
+        uint256 msgId = buildHash(msg.pubkey(), uniqueId, initTime);
+
+        emit MailBroadcast{dest: address.makeAddrExtern(msg.sender.value, 256)}(msgId);
+
+        if (broadcastFee > 0) {
+            beneficiary.transfer({ value: uint128(broadcastFee), bounce: false });
+        }
+
+        msg.sender.transfer({ value: 0, flag: 128, bounce: false });
+    }
+}

--- a/contracts/YlideMailerV7.tsol
+++ b/contracts/YlideMailerV7.tsol
@@ -76,7 +76,7 @@ contract YlideMailerV7 is Owned, Terminatable {
             address recipientAddr = address.makeAddrExtern(recipients[i].value, 256);
             emit MailPush{dest: recipientAddr}(msg.sender, msgId, keys[i]);
         }
-        emit ContentRecipients{dest: address.makeAddrExtern(msgId, 256)}(msg.sender, msgId, recipients);
+        emit ContentRecipients{dest: address.makeAddrExtern(msgId + 1, 256)}(msg.sender, msgId, recipients);
 
         if (recipientFee * recipients.length > 0) {
             beneficiary.transfer({ value: uint128(recipientFee * recipients.length), bounce: false });
@@ -98,7 +98,7 @@ contract YlideMailerV7 is Owned, Terminatable {
 
         emit MailContent{dest: fakeContentAddr}(msg.sender, msgId, 1, 0, content);
         emit MailPush{dest: recipientAddr}(msg.sender, msgId, key);
-        emit ContentRecipients{dest: fakeContentAddr}(msg.sender, msgId, recipients);
+        emit ContentRecipients{dest: address.makeAddrExtern(msgId + 1, 256)}(msg.sender, msgId, recipients);
 
         if (contentPartFee + recipientFee > 0) {
             beneficiary.transfer({ value: uint128(contentPartFee + recipientFee), bounce: false });
@@ -121,7 +121,7 @@ contract YlideMailerV7 is Owned, Terminatable {
             emit MailPush{dest: recipientAddr}(msg.sender, msgId, keys[i]);
         }
 
-        emit ContentRecipients{dest: fakeContentAddr}(msg.sender, msgId, recipients);
+        emit ContentRecipients{dest: address.makeAddrExtern(msgId + 1, 256)}(msg.sender, msgId, recipients);
 
         if (contentPartFee + recipientFee * recipients.length > 0) {
             beneficiary.transfer({ value: uint128(contentPartFee + recipientFee * recipients.length), bounce: false });

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
 		"test": "test"
 	},
 	"scripts": {
-		"test": "echo \"Error: no test specified\" && exit 1",
+		"test": "npx locklift test -n local",
 		"build": "rm -rf ./build && locklift build",
 		"deploy": "locklift run --disable-build --network local --script scripts/1-deploy-contracts.ts",
 		"deploy:account": "locklift run --disable-build --network local --script scripts/2-deploy-account.ts",

--- a/scripts/1-deploy-contracts.ts
+++ b/scripts/1-deploy-contracts.ts
@@ -1,48 +1,48 @@
-import { Address } from "locklift";
+import { Address } from 'locklift';
 
 async function main() {
-    const signer = (await locklift.keystore.getSigner("0"))!;
+	const signer = (await locklift.keystore.getSigner('0'))!;
 
-    const mailer = await locklift.factory.deployContract({
-        contract: "YlideMailerV6",
-        constructorParams: {},
-        initParams: {
-            nonce: 0,
-            beneficiary: new Address("0:dc0e6248fa1f599fd1c2ac40d3ba2342d6eaaac4b19767063f939997dcbc66c2"),
-        },
-        publicKey: signer.publicKey,
-        value: locklift.utils.toNano(3),
-    });
+	const mailer = await locklift.factory.deployContract({
+		contract: 'YlideMailerV6',
+		constructorParams: {},
+		initParams: {
+			nonce: 0,
+			beneficiary: new Address('0:dc0e6248fa1f599fd1c2ac40d3ba2342d6eaaac4b19767063f939997dcbc66c2'),
+		},
+		publicKey: signer.publicKey,
+		value: locklift.utils.toNano(3),
+	});
 
-    const broadcaster = await locklift.factory.deployContract({
-        contract: "YlideMailerV6",
-        constructorParams: {},
-        initParams: {
-            nonce: 0,
-            beneficiary: new Address("0:86c4c21b15f373d77e80d6449358cfe59fc9a03e756052ac52258d8dd0ceb977"),
-        },
-        publicKey: signer.publicKey,
-        value: locklift.utils.toNano(3),
-    });
+	const broadcaster = await locklift.factory.deployContract({
+		contract: 'YlideMailerV6',
+		constructorParams: {},
+		initParams: {
+			nonce: 0,
+			beneficiary: new Address('0:86c4c21b15f373d77e80d6449358cfe59fc9a03e756052ac52258d8dd0ceb977'),
+		},
+		publicKey: signer.publicKey,
+		value: locklift.utils.toNano(3),
+	});
 
-    const registry = await locklift.factory.deployContract({
-        contract: "YlideRegistryV2",
-        constructorParams: {},
-        initParams: {
-            nonce: 0,
-        },
-        publicKey: signer.publicKey,
-        value: locklift.utils.toNano(3),
-    });
+	const registry = await locklift.factory.deployContract({
+		contract: 'YlideRegistryV2',
+		constructorParams: {},
+		initParams: {
+			nonce: 0,
+		},
+		publicKey: signer.publicKey,
+		value: locklift.utils.toNano(3),
+	});
 
-    console.log(`Mailer deployed at: ${mailer.contract.address}`);
-    console.log(`Broadcaster deployed at: ${broadcaster.contract.address}`);
-    console.log(`Registry deployed at: ${registry.contract.address}`);
+	console.log(`Mailer deployed at: ${mailer.contract.address}`);
+	console.log(`Broadcaster deployed at: ${broadcaster.contract.address}`);
+	console.log(`Registry deployed at: ${registry.contract.address}`);
 }
 
 main()
-    .then(() => process.exit(0))
-    .catch(e => {
-        console.log(e);
-        process.exit(1);
-    });
+	.then(() => process.exit(0))
+	.catch(e => {
+		console.log(e);
+		process.exit(1);
+	});

--- a/scripts/2-deploy-account.ts
+++ b/scripts/2-deploy-account.ts
@@ -1,16 +1,16 @@
-import { Address } from "locklift";
+import { Address } from 'locklift';
 
 async function main() {
-    const result = await locklift.giver.sendTo(
-        new Address("0:86c4c21b15f373d77e80d6449358cfe59fc9a03e756052ac52258d8dd0ceb977"),
-        locklift.utils.toNano(3),
-    );
-    console.log("result: ", result);
+	const result = await locklift.giver.sendTo(
+		new Address('0:86c4c21b15f373d77e80d6449358cfe59fc9a03e756052ac52258d8dd0ceb977'),
+		locklift.utils.toNano(3),
+	);
+	console.log('result: ', result);
 }
 
 main()
-    .then(() => process.exit(0))
-    .catch(e => {
-        console.log(e);
-        process.exit(1);
-    });
+	.then(() => process.exit(0))
+	.catch(e => {
+		console.log(e);
+		process.exit(1);
+	});

--- a/scripts/utils.ts
+++ b/scripts/utils.ts
@@ -1,0 +1,5 @@
+import crypto from 'crypto';
+import { Address } from 'locklift';
+
+export const getRandomBytes = (length = 32) => crypto.randomBytes(length).toString('hex');
+export const getRandomAddress = () => new Address('0:' + crypto.randomBytes(32).toString('hex'));

--- a/test/ylideMailerV7.ts
+++ b/test/ylideMailerV7.ts
@@ -1,0 +1,115 @@
+import { expect } from 'chai';
+import { Account } from 'everscale-standalone-client';
+import { Contract, Signer, WalletTypes } from 'locklift';
+import { FactorySource } from '../build/factorySource';
+import { getRandomAddress, getRandomBytes } from '../scripts/utils';
+
+describe('Test YlideMailerV7 contract', async function () {
+	let mailer: Contract<FactorySource['YlideMailerV7']>;
+	let signer: Signer;
+	let user: Account;
+
+	const uniqueId = 123;
+	const recipients = [getRandomAddress(), getRandomAddress()];
+	const keys = [getRandomBytes(), getRandomBytes()];
+	const content = getRandomBytes(56);
+
+	before(async () => {
+		signer = (await locklift.keystore.getSigner('0'))!;
+		const r = await locklift.factory.accounts.addNewAccount({
+			type: WalletTypes.WalletV3,
+			publicKey: signer.publicKey,
+			value: locklift.utils.toNano(100),
+		});
+		user = r.account;
+	});
+
+	describe('Contracts', async function () {
+		it('Load contract factory', function () {
+			const sampleData = locklift.factory.getContractArtifacts('YlideMailerV7');
+
+			expect(sampleData.code).not.to.equal(undefined, 'Code should be available');
+			expect(sampleData.abi).not.to.equal(undefined, 'ABI should be available');
+			expect(sampleData.tvc).not.to.equal(undefined, 'tvc should be available');
+		});
+
+		it('Deploy contract', async function () {
+			const { contract } = await locklift.factory.deployContract({
+				contract: 'YlideMailerV7',
+				publicKey: signer.publicKey,
+				initParams: {
+					nonce: 0,
+					beneficiary: recipients[0],
+				},
+				constructorParams: {},
+				value: locklift.utils.toNano(2),
+			});
+			mailer = contract;
+
+			expect(await locklift.provider.getBalance(mailer.address).then(balance => Number(balance))).to.be.above(0);
+		});
+
+		it('sendSmallMail', async function () {
+			const { parentTransaction, childTransaction } = await mailer.methods
+				.sendSmallMail({
+					uniqueId,
+					recipient: recipients[0],
+					key: keys[0],
+					content,
+				})
+				.sendWithResult({
+					from: user.address,
+					amount: locklift.utils.toNano(10),
+					bounce: false,
+				});
+
+			expect(parentTransaction.aborted).equal(false);
+			expect(childTransaction.aborted).equal(false);
+
+			expect(parentTransaction.outMessages.length).equal(1);
+			expect(childTransaction.outMessages.length).equal(4);
+		});
+
+		it('sendBulkMail', async function () {
+			const { parentTransaction, childTransaction } = await mailer.methods
+				.sendBulkMail({
+					uniqueId,
+					recipients: recipients,
+					keys,
+					content,
+				})
+				.sendWithResult({
+					from: user.address,
+					amount: locklift.utils.toNano(10),
+					bounce: false,
+				});
+
+			expect(parentTransaction.aborted).equal(false);
+			expect(childTransaction.aborted).equal(false);
+
+			expect(parentTransaction.outMessages.length).equal(1);
+			expect(childTransaction.outMessages.length).equal(5);
+		});
+
+		it('addRecipients', async function () {
+			const { parentTransaction, childTransaction } = await mailer.methods
+				.addRecipients({
+					uniqueId,
+					recipients: recipients,
+					keys,
+					initTime: 123,
+				})
+				.sendWithResult({
+					from: user.address,
+					amount: locklift.utils.toNano(10),
+					bounce: false,
+				});
+
+			expect(parentTransaction.aborted).equal(false);
+			expect(childTransaction.aborted).equal(false);
+
+			expect(parentTransaction.outMessages.length).equal(1);
+			expect(childTransaction.outMessages.length).equal(4);
+		});
+	});
+});


### PR DESCRIPTION
Support gathering information on recipients. Similarly to ethereum-contracts emit event containing contentId with list of recipients. Send ContentRecipients message to (fake address + 1) like MailContent event to allow indexing of those particular events.